### PR TITLE
Disable fixme pylint check.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -421,14 +421,15 @@ confidence=HIGH,
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=raw-checker-failed,
-        bad-inline-option,
-        locally-disabled,
-        file-ignored,
-        suppressed-message,
-        useless-suppression,
+disable=bad-inline-option,
         deprecated-pragma,
+        file-ignored,
+        fixme,
+        locally-disabled,
+        raw-checker-failed,
+        suppressed-message,
         use-symbolic-message-instead,
+        useless-suppression,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
It's useful to be able to leave TODO, etc. comments in the code without pylint failing.