### PR TITLE
Delete unnecessary .markdownlintignore file.

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,0 @@
-pylintrc


### PR DESCRIPTION
Delete the ignore file added in https://github.com/pedantic-curmudgeon/python_project_template/pull/3.

The issue was that Visual Studio Code was incorrectly auto-detecting to the Markdown Language Mode when editing the pylintrc file. Setting the Language Mode to Plain Text when the pylintrc file is open resolves the issue, which makes the previous change of adding a .markdownlintignore file unnecessary.