### PR TITLE
Fix syntax error in dependabot group patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     groups:
       all:
         patterns:
-          '*'
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,4 +16,4 @@ updates:
     groups:
       all:
         patterns:
-          '*'
+          - "*"


### PR DESCRIPTION
- Fix syntax error to pass an array instead of a string.
- Make quote character consistent with the rest of the file.

https://github.com/pedantic-curmudgeon/python_project_template/runs/15853853485